### PR TITLE
Universal framework support + accuracy diagnostics + per-framework examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,45 @@ additions (ALE, anchors) and a 2024–2025 research frontier most tools skip:
 | Metrics | classification + regression | accuracy/precision/recall/f1/auc, r²/mae/rmse |
 | Monitoring | **data drift** (PSI + KS) | reference vs. current dataset |
 | **LLM narration** | Claude (`claude-opus-4-8`) | plain-language briefings / Q&A grounded in the report |
-| Reporting | **HTML export** + **CLI** | shareable artifact; no-code usage |
+| Reporting | **HTML export** + **CLI** + **dashboard** | shareable artifact; no-code usage |
 
-Works with any estimator following the scikit-learn `predict` / `predict_proba`
-convention (scikit-learn, XGBoost, LightGBM, CatBoost, …).
+### Improve accuracy (data-centric diagnostics)
+
+Beyond explaining a model, explainX helps you make it **more accurate** — the
+data-centric-AI playbook, returned as actionable reports:
+
+| Diagnostic | What it finds | Why it improves accuracy |
+|---|---|---|
+| **Error analysis** | data slices with the highest error (slice discovery) | tells you where to add data / features or split the model |
+| **Label issues** | likely-mislabeled rows (confident learning) | cleaning labels is often the highest-ROI accuracy lever |
+| **Target leakage** | features that alone predict the target | catches inflated offline accuracy that collapses in production |
+| **Calibration** | ECE / Brier + reliability | flags untrustworthy probabilities and recommends a fix |
+
+```python
+ex.error_analysis()   # ErrorAnalysis: worst slices + recommendation
+ex.label_issues()     # LabelIssues: rows to relabel (cross-validated)
+ex.leakage()          # LeakageReport: suspected leaky features
+ex.calibration()      # CalibrationReport: ECE, Brier, fix recommendation
+```
+
+## Works with any ML framework
+
+explainX speaks the scikit-learn `predict` / `predict_proba` convention, so many
+frameworks work **with no wrapping**: scikit-learn, **XGBoost**, **LightGBM**,
+**CatBoost** (their sklearn-API estimators). For anything else, `wrap_model()`
+adapts it — native XGBoost/LightGBM `Booster`s, **Keras/TensorFlow**, **PyTorch**,
+**statsmodels**, or any custom prediction function:
+
+```python
+from explainx import explain_model, wrap_model
+
+explain_model(sklearn_or_xgb_or_lgbm_or_catboost_model, X, y)      # direct
+explain_model(wrap_model(keras_or_torch_model, task="classification"), X, y)
+explain_model(wrap_model(predict_proba_fn=my_api_call, classes=[0, 1]), X, y)
+```
+
+Runnable, studyable examples for **every** framework live in
+[`examples/`](examples/) (one file per framework).
 
 ## Install
 
@@ -207,6 +242,10 @@ The agent saves a fitted model and dataset to disk, then calls tools by path:
 | `feature_interactions_tool` | Strongest pairwise interactions (H-statistic) |
 | `prototypes_and_criticisms_tool` | Representative + atypical rows |
 | `detect_data_drift` | Distribution drift between two datasets |
+| `error_analysis` | Worst-performing data slices (slice discovery) |
+| `label_issues` | Likely-mislabeled rows (confident learning) |
+| `detect_target_leakage` | Features that leak the target |
+| `assess_calibration` | Probability calibration (ECE / Brier) |
 | `html_report` | Write a shareable HTML report |
 
 Each returns a JSON-ready dict the agent can reason over — e.g. read a

--- a/examples/01_sklearn.py
+++ b/examples/01_sklearn.py
@@ -1,0 +1,16 @@
+"""explainX with scikit-learn — works directly, no wrapping.
+
+    python examples/01_sklearn.py
+"""
+
+from sklearn.ensemble import RandomForestClassifier
+
+from explainx import explain_model, ModelExplainer
+from _common import loan_data, show
+
+X, y = loan_data()
+model = RandomForestClassifier(n_estimators=80, random_state=0).fit(X, y)
+
+# Any scikit-learn estimator is consumed directly.
+report = explain_model(model, X, y, sensitive_features=["gender"], n_local=1)
+show(report, ModelExplainer(model, X, y))

--- a/examples/02_xgboost.py
+++ b/examples/02_xgboost.py
@@ -1,0 +1,26 @@
+"""explainX with XGBoost — both the sklearn API and the native Booster.
+
+    pip install xgboost
+    python examples/02_xgboost.py
+"""
+
+import xgboost as xgb
+
+from explainx import explain_model, ModelExplainer, wrap_model
+from _common import loan_data, show
+
+X, y = loan_data()
+
+# 1) sklearn API (XGBClassifier) — works directly, no wrapping.
+print("=== XGBClassifier (sklearn API) ===")
+clf = xgb.XGBClassifier(n_estimators=60, max_depth=3, verbosity=0).fit(X, y)
+report = explain_model(clf, X, y, sensitive_features=["gender"], n_local=1)
+show(report, ModelExplainer(clf, X, y))
+
+# 2) native Booster (xgboost.train) — wrap it; tell explainX it's classification.
+print("\n=== native xgboost.Booster (via wrap_model) ===")
+booster = xgb.train({"objective": "binary:logistic", "max_depth": 3},
+                    xgb.DMatrix(X, label=y), num_boost_round=60)
+ex = ModelExplainer(wrap_model(booster, task="classification"), X, y)
+print(ex.metrics().to_dict()["metrics"])
+print("Top features:", [f.feature for f in ex.importance().top(3)])

--- a/examples/03_lightgbm.py
+++ b/examples/03_lightgbm.py
@@ -1,0 +1,25 @@
+"""explainX with LightGBM — sklearn API and native Booster.
+
+    pip install lightgbm
+    python examples/03_lightgbm.py
+"""
+
+import lightgbm as lgb
+
+from explainx import explain_model, ModelExplainer, wrap_model
+from _common import loan_data, show
+
+X, y = loan_data()
+
+# 1) sklearn API (LGBMClassifier) — works directly.
+print("=== LGBMClassifier (sklearn API) ===")
+clf = lgb.LGBMClassifier(n_estimators=60, verbose=-1).fit(X, y)
+report = explain_model(clf, X, y, sensitive_features=["gender"], n_local=1)
+show(report, ModelExplainer(clf, X, y))
+
+# 2) native Booster — wrap it.
+print("\n=== native lightgbm.Booster (via wrap_model) ===")
+booster = lgb.train({"objective": "binary", "verbose": -1},
+                    lgb.Dataset(X, label=y), num_boost_round=60)
+ex = ModelExplainer(wrap_model(booster, task="classification"), X, y)
+print(ex.metrics().to_dict()["metrics"])

--- a/examples/04_catboost.py
+++ b/examples/04_catboost.py
@@ -1,0 +1,17 @@
+"""explainX with CatBoost — works directly (CatBoost follows the sklearn API).
+
+    pip install catboost
+    python examples/04_catboost.py
+"""
+
+from catboost import CatBoostClassifier
+
+from explainx import explain_model, ModelExplainer
+from _common import loan_data, show
+
+X, y = loan_data()
+model = CatBoostClassifier(iterations=120, depth=4, verbose=0).fit(X, y)
+
+# CatBoostClassifier has predict / predict_proba, so explainX uses it directly.
+report = explain_model(model, X, y, sensitive_features=["gender"], n_local=1)
+show(report, ModelExplainer(model, X, y))

--- a/examples/05_keras_tensorflow.py
+++ b/examples/05_keras_tensorflow.py
@@ -1,0 +1,35 @@
+"""explainX with a Keras / TensorFlow model — wrap it with wrap_model.
+
+A Keras model's .predict returns class probabilities but it has no
+predict_proba, so wrap_model adapts it. For binary problems use a single
+sigmoid output; explainX reads it as P(positive class).
+
+    pip install tensorflow
+    python examples/05_keras_tensorflow.py
+"""
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+from explainx import ModelExplainer, wrap_model
+from _common import loan_data
+
+X, y = loan_data()
+Xv = X.to_numpy().astype("float32")
+
+model = keras.Sequential([
+    keras.layers.Input(shape=(X.shape[1],)),
+    keras.layers.Dense(16, activation="relu"),
+    keras.layers.Dense(1, activation="sigmoid"),
+])
+model.compile(optimizer="adam", loss="binary_crossentropy")
+model.fit(Xv, y, epochs=15, batch_size=32, verbose=0)
+
+# wrap_model detects Keras; task is inferred from the sigmoid output (classification).
+ex = ModelExplainer(wrap_model(model, task="classification"), X, y)
+print(ex.metrics().to_dict()["metrics"])
+print("Top features:", [f.feature for f in ex.importance().top(3)])
+local = ex.explain(0, top_k=3)
+print(f"Row 0 -> {local.prediction} via {local.method}")
+print(ex.fairness("gender").findings[0])

--- a/examples/06_pytorch.py
+++ b/examples/06_pytorch.py
@@ -1,0 +1,45 @@
+"""explainX with a PyTorch model — wrap the nn.Module with wrap_model.
+
+wrap_model detects an nn.Module, runs it under torch.no_grad(), and reads the
+output as class probabilities. Here we use a 2-logit + softmax head so the
+output is a (n, 2) probability matrix.
+
+    pip install torch
+    python examples/06_pytorch.py
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from explainx import ModelExplainer, wrap_model
+from _common import loan_data
+
+X, y = loan_data()
+Xt = torch.tensor(X.to_numpy(), dtype=torch.float32)
+yt = torch.tensor(y, dtype=torch.long)
+
+
+class Net(nn.Module):
+    def __init__(self, d):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(d, 16), nn.ReLU(), nn.Linear(16, 2), nn.Softmax(dim=1))
+
+    def forward(self, x):
+        return self.net(x)
+
+
+model = Net(X.shape[1])
+opt = torch.optim.Adam(model.parameters(), lr=0.01)
+loss_fn = nn.CrossEntropyLoss()
+for _ in range(150):
+    opt.zero_grad()
+    loss = loss_fn(torch.log(model(Xt) + 1e-9), yt)
+    loss.backward()
+    opt.step()
+
+# wrap_model detects torch.nn.Module; the (n, 2) softmax output -> classification.
+ex = ModelExplainer(wrap_model(model, task="classification", classes=[0, 1]), X, y)
+print(ex.metrics().to_dict()["metrics"])
+print("Top features:", [f.feature for f in ex.importance().top(3)])
+print(ex.fairness("gender").findings[0])

--- a/examples/07_statsmodels.py
+++ b/examples/07_statsmodels.py
@@ -1,0 +1,35 @@
+"""explainX with statsmodels — wrap the fitted results with wrap_model.
+
+statsmodels' .predict returns the positive-class probability (Logit) or the
+predicted value (OLS), with no sklearn API, so wrap_model adapts it. Pass
+task= so explainX knows whether it's classification or regression.
+
+    pip install statsmodels
+    python examples/07_statsmodels.py
+"""
+
+import numpy as np
+import statsmodels.api as sm
+
+from explainx import ModelExplainer, wrap_model
+from _common import loan_data
+
+X, y = loan_data()
+Xc = sm.add_constant(X)  # statsmodels needs an explicit intercept column
+
+logit = sm.Logit(y, Xc).fit(disp=0)
+
+# The wrapped predict() must receive the same columns the model was fit on, so
+# we re-add the constant inside a custom predict_proba_fn.
+def _design(Z):
+    import pandas as pd
+    Z = Z if hasattr(Z, "columns") else pd.DataFrame(Z, columns=X.columns)
+    return sm.add_constant(Z, has_constant="add")
+
+ex = ModelExplainer(
+    wrap_model(predict_proba_fn=lambda Z: logit.predict(_design(Z)), classes=[0, 1]),
+    X, y,
+)
+print(ex.metrics().to_dict()["metrics"])
+print("Top features:", [f.feature for f in ex.importance().top(3)])
+print(ex.fairness("gender").findings[0])

--- a/examples/08_custom_predict_fn.py
+++ b/examples/08_custom_predict_fn.py
@@ -1,0 +1,32 @@
+"""explainX with ANY model via a custom prediction function.
+
+If your model isn't one of the known frameworks — a remote API, an ONNX
+runtime, an ensemble, a hand-written rule — just give wrap_model a function.
+
+* classification: pass predict_proba_fn (returns per-class probabilities)
+* regression:     pass predict_fn (returns the predicted value)
+
+    python examples/08_custom_predict_fn.py
+"""
+
+import numpy as np
+from sklearn.ensemble import GradientBoostingClassifier
+
+from explainx import ModelExplainer, wrap_model
+from _common import loan_data
+
+X, y = loan_data()
+
+# Pretend this is an opaque model we can only call through a function.
+_backend = GradientBoostingClassifier(random_state=0).fit(X, y)
+def my_predict_proba(rows):
+    """rows: a DataFrame or array -> (n, n_classes) probability matrix."""
+    return _backend.predict_proba(rows)
+
+ex = ModelExplainer(wrap_model(predict_proba_fn=my_predict_proba, classes=[0, 1]), X, y)
+print(ex.metrics().to_dict()["metrics"])
+print("Top features:", [f.feature for f in ex.importance().top(3)])
+local = ex.explain(0, top_k=3)
+print(f"Row 0 -> {local.prediction}: "
+      + ", ".join(f"{c.feature} ({c.contribution:+.3f})" for c in local.contributions))
+print(ex.fairness("gender").findings[0])

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,34 @@
+# explainX framework examples
+
+Runnable, self-contained examples showing **explainX with every major ML
+framework** — for humans to study and for LLM agents to learn the API from.
+
+explainX speaks the scikit-learn convention (`predict` / `predict_proba`), so
+many frameworks work **with no wrapping at all**. For the rest, `wrap_model()`
+adapts them.
+
+| Example | Framework | Wrapping needed? |
+|---|---|---|
+| [`01_sklearn.py`](01_sklearn.py) | scikit-learn | none |
+| [`02_xgboost.py`](02_xgboost.py) | XGBoost (sklearn API **and** native `Booster`) | native Booster → `wrap_model` |
+| [`03_lightgbm.py`](03_lightgbm.py) | LightGBM (sklearn API and native `Booster`) | native Booster → `wrap_model` |
+| [`04_catboost.py`](04_catboost.py) | CatBoost | none |
+| [`05_keras_tensorflow.py`](05_keras_tensorflow.py) | Keras / TensorFlow | `wrap_model` |
+| [`06_pytorch.py`](06_pytorch.py) | PyTorch | `wrap_model` |
+| [`07_statsmodels.py`](07_statsmodels.py) | statsmodels | `wrap_model(task=...)` |
+| [`08_custom_predict_fn.py`](08_custom_predict_fn.py) | any model / API | `wrap_model(predict_fn=...)` |
+
+Run any of them:
+
+```sh
+pip install "explainx[all]"      # plus the framework, e.g. pip install xgboost
+python examples/02_xgboost.py
+```
+
+Each script trains a small model, then runs explainX — a full report plus a few
+individual modules — and prints the structured results.
+
+**Rule of thumb for agents:** if a model has `.predict` (and `.predict_proba`
+for classification), pass it straight to `explain_model(model, X, y)`. Otherwise
+wrap it: `explain_model(wrap_model(model, task="classification"), X, y)`, or for a
+fully custom model `wrap_model(predict_fn=fn)` / `wrap_model(predict_proba_fn=fn)`.

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,0 +1,30 @@
+"""Shared helpers for the framework examples (a small, slightly biased dataset)."""
+
+import numpy as np
+import pandas as pd
+
+
+def loan_data(n=600, seed=0):
+    """A tiny loan-approval dataset with a mild gender effect, for demos."""
+    rng = np.random.RandomState(seed)
+    gender = rng.randint(0, 2, n)
+    income = rng.normal(50, 15, n)
+    credit_score = rng.normal(650, 80, n)
+    debt_ratio = rng.uniform(0, 1, n)
+    approved = (
+        0.04 * (income - 50) + 0.02 * (credit_score - 650) - 2.5 * debt_ratio
+        + 1.0 * gender + rng.normal(0, 0.5, n) > 0
+    ).astype(int)
+    X = pd.DataFrame({"gender": gender, "income": income, "credit_score": credit_score, "debt_ratio": debt_ratio})
+    return X, approved
+
+
+def show(report, ex=None):
+    """Print a compact view of an explainX report and a couple of modules."""
+    print(report.summary)
+    if ex is not None:
+        top = ex.importance().top(3)
+        print("\nTop features:", ", ".join(f"{f.feature}={f.importance:.3f}" for f in top))
+        local = ex.explain(0, top_k=3)
+        drivers = ", ".join(f"{c.feature} ({c.contribution:+.3f})" for c in local.contributions)
+        print(f"Row 0 -> {local.prediction} via {local.method}: {drivers}")

--- a/explainx/__init__.py
+++ b/explainx/__init__.py
@@ -47,6 +47,8 @@ from .drift import detect_drift
 from .report_html import report_to_html, save_html
 from .conformal import conformal_predict
 from .prototypes import prototypes_and_criticisms
+from .adapters import wrap_model
+from .diagnostics import error_analysis, find_label_issues, detect_leakage, assess_calibration
 
 __all__ = [
     "explain_model",
@@ -78,6 +80,11 @@ __all__ = [
     "PrototypesResult",
     "conformal_predict",
     "prototypes_and_criticisms",
+    "wrap_model",
+    "error_analysis",
+    "find_label_issues",
+    "detect_leakage",
+    "assess_calibration",
 ]
 
 __version__ = "3.0.0"

--- a/explainx/adapters.py
+++ b/explainx/adapters.py
@@ -1,0 +1,266 @@
+"""Universal model adapter — make explainX work with any ML framework.
+
+The engine speaks the scikit-learn convention (``predict`` / ``predict_proba`` /
+``classes_``). Many libraries already follow it, so they work with **zero
+wrapping**:
+
+* scikit-learn (every estimator)
+* XGBoost   — ``XGBClassifier`` / ``XGBRegressor``
+* LightGBM  — ``LGBMClassifier`` / ``LGBMRegressor``
+* CatBoost  — ``CatBoostClassifier`` / ``CatBoostRegressor``
+
+For frameworks that *don't* expose that API, :func:`wrap_model` adapts them into
+it: native XGBoost / LightGBM ``Booster`` objects, Keras / TensorFlow models,
+PyTorch ``nn.Module``\\s, statsmodels results, or any custom ``predict_fn``.
+
+``ModelExplainer`` calls :func:`wrap_model` automatically, so in practice you can
+pass almost any trained model directly; reach for ``wrap_model`` explicitly only
+when you need to pass a custom prediction function or override the task/classes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Sequence
+import numpy as np
+
+
+def _is_frame(X) -> bool:
+    try:
+        import pandas as pd
+
+        return isinstance(X, (pd.DataFrame, pd.Series))
+    except Exception:
+        return False
+
+
+def _to_numpy(X) -> np.ndarray:
+    if _is_frame(X):
+        return X.to_numpy()
+    return np.asarray(X)
+
+
+def is_sklearn_compatible(model: Any) -> bool:
+    """True if the engine can use the model as-is (no wrapping needed)."""
+    try:
+        from sklearn.base import is_classifier, is_regressor
+
+        if is_classifier(model) or is_regressor(model):
+            return True
+    except Exception:
+        pass
+    # CatBoost / other duck-typed estimators expose predict_proba or predict+classes_.
+    if hasattr(model, "predict") and (hasattr(model, "predict_proba") or hasattr(model, "_estimator_type")):
+        return True
+    return False
+
+
+def detect_framework(model: Any) -> str:
+    module = type(model).__module__.split(".")[0]
+    cls = type(model).__name__
+    if module == "xgboost" and cls == "Booster":
+        return "xgboost_booster"
+    if module == "lightgbm" and cls == "Booster":
+        return "lightgbm_booster"
+    if module in ("keras", "tensorflow", "tf_keras"):
+        return "keras"
+    try:
+        import torch
+
+        if isinstance(model, torch.nn.Module):
+            return "torch"
+    except Exception:
+        pass
+    if module == "statsmodels":
+        return "statsmodels"
+    if is_sklearn_compatible(model):
+        return "sklearn"
+    if callable(getattr(model, "predict", None)):
+        return "sklearn"  # best-effort duck typing
+    return "unknown"
+
+
+class ModelAdapter:
+    """Wraps an arbitrary model in the scikit-learn predict/predict_proba API."""
+
+    def __init__(
+        self,
+        predict_fn: Callable,
+        predict_proba_fn: Optional[Callable] = None,
+        classes: Optional[Sequence] = None,
+        problem_type: Optional[str] = None,
+        name: str = "WrappedModel",
+    ):
+        self._predict_fn = predict_fn
+        self._predict_proba_fn = predict_proba_fn
+        self._name = name
+        self.problem_type = problem_type
+        if classes is not None:
+            self.classes_ = np.asarray(classes)
+        if predict_proba_fn is not None:
+            # Expose predict_proba only when available, so detection works.
+            self.predict_proba = self._predict_proba  # type: ignore[assignment]
+
+    def predict(self, X):
+        return np.asarray(self._predict_fn(X))
+
+    def _predict_proba(self, X):
+        return np.asarray(self._predict_proba_fn(X))
+
+    def __repr__(self):
+        return f"ModelAdapter({self._name})"
+
+
+def _proba_to_classes(proba: np.ndarray):
+    proba = np.asarray(proba)
+    if proba.ndim == 1 or proba.shape[1] == 1:
+        return np.array([0, 1])
+    return np.arange(proba.shape[1])
+
+
+def _from_proba_predict(proba: np.ndarray, classes: np.ndarray):
+    proba = np.asarray(proba)
+    if proba.ndim == 1:
+        return (proba >= 0.5).astype(int)
+    if proba.shape[1] == 1:
+        return (proba[:, 0] >= 0.5).astype(int)
+    return classes[np.argmax(proba, axis=1)]
+
+
+def _two_col(proba: np.ndarray) -> np.ndarray:
+    """Normalize a 1-column / 1-D probability into a 2-column [neg, pos] matrix."""
+    proba = np.asarray(proba, dtype=float)
+    if proba.ndim == 1:
+        proba = proba.reshape(-1, 1)
+    if proba.shape[1] == 1:
+        return np.hstack([1 - proba, proba])
+    return proba
+
+
+def wrap_model(
+    model: Any = None,
+    *,
+    predict_fn: Optional[Callable] = None,
+    predict_proba_fn: Optional[Callable] = None,
+    classes: Optional[Sequence] = None,
+    task: Optional[str] = None,
+    framework: Optional[str] = None,
+) -> Any:
+    """Return a model usable by the engine, wrapping non-sklearn frameworks.
+
+    sklearn-compatible models (incl. XGBoost/LightGBM/CatBoost sklearn wrappers)
+    are returned unchanged. Pass ``predict_fn`` (+ optional ``predict_proba_fn``,
+    ``classes``) to wrap a fully custom model. ``task`` is ``"classification"`` or
+    ``"regression"`` and helps when it can't be inferred.
+    """
+    # 1. Fully custom prediction functions.
+    if predict_fn is not None or predict_proba_fn is not None:
+        if predict_proba_fn is not None and predict_fn is None:
+            # Derive predict() by thresholding/argmaxing the probabilities.
+            def _pred(X, _f=predict_proba_fn, _c=classes):
+                p = np.asarray(_f(X))
+                c = np.asarray(_c) if _c is not None else _proba_to_classes(p)
+                return _from_proba_predict(p, c)
+            return ModelAdapter(
+                _pred, predict_proba_fn, classes=classes, problem_type="classification", name="custom"
+            )
+        return ModelAdapter(predict_fn, predict_proba_fn, classes=classes, problem_type=task, name="custom")
+
+    if model is None:
+        raise TypeError("wrap_model() needs a model, or a predict_fn / predict_proba_fn.")
+
+    fw = framework or detect_framework(model)
+
+    if fw in ("sklearn", "unknown"):
+        if fw == "unknown":
+            raise TypeError(
+                f"Could not adapt model of type {type(model).__name__}. Pass predict_fn "
+                "(and predict_proba_fn for classification) to wrap_model()."
+            )
+        return model  # already usable
+
+    if fw == "xgboost_booster":
+        import xgboost
+
+        def raw(X):
+            # Pass the DataFrame straight through so DMatrix keeps feature names
+            # (the Booster validates names when it was trained with them).
+            dm = xgboost.DMatrix(X if _is_frame(X) else _to_numpy(X))
+            return np.asarray(model.predict(dm))
+        return _wrap_raw_scores(raw, task, classes, name="xgboost.Booster")
+
+    if fw == "lightgbm_booster":
+        def raw(X):
+            return np.asarray(model.predict(X if _is_frame(X) else _to_numpy(X)))
+        return _wrap_raw_scores(raw, task, classes, name="lightgbm.Booster")
+
+    if fw == "keras":
+        def raw(X):
+            return np.asarray(model.predict(_to_numpy(X), verbose=0))
+        return _wrap_raw_scores(raw, task, classes, name="keras.Model")
+
+    if fw == "torch":
+        import torch
+
+        def raw(X):
+            model.eval()
+            with torch.no_grad():
+                out = model(torch.as_tensor(_to_numpy(X), dtype=torch.float32))
+            return out.detach().cpu().numpy()
+        return _wrap_raw_scores(raw, task, classes, name="torch.nn.Module")
+
+    if fw == "statsmodels":
+        def _pred(X):
+            return np.asarray(model.predict(_to_numpy(X)))
+        # statsmodels results are usually regression / single-prob outputs.
+        if task == "classification":
+            def _pp(X):
+                return _two_col(model.predict(_to_numpy(X)))
+            return ModelAdapter(
+                lambda X: _from_proba_predict(model.predict(_to_numpy(X)), np.array([0, 1])),
+                _pp, classes=classes or [0, 1], problem_type="classification", name="statsmodels",
+            )
+        return ModelAdapter(_pred, problem_type="regression", name="statsmodels")
+
+    return model
+
+
+def _wrap_raw_scores(raw_fn: Callable, task: Optional[str], classes, name: str) -> ModelAdapter:
+    """Build an adapter from a function returning raw scores/probabilities.
+
+    Heuristic when ``task`` is unset: a 2-D output (k>1 columns) is multiclass
+    probabilities; a 1-D output in [0, 1] is binary probability; anything else is
+    treated as a regression value.
+    """
+    sample = None
+
+    def infer_task(p):
+        p = np.asarray(p)
+        if p.ndim == 2 and p.shape[1] > 1:
+            return "classification"
+        flat = p.reshape(-1)
+        if flat.size and flat.min() >= 0.0 and flat.max() <= 1.0:
+            return "classification"
+        return "regression"
+
+    resolved_task = task
+
+    def predict(X):
+        nonlocal resolved_task
+        p = raw_fn(X)
+        if resolved_task is None:
+            resolved_task = infer_task(p)
+        if resolved_task == "regression":
+            arr = np.asarray(p)
+            return arr.reshape(-1) if arr.ndim > 1 and arr.shape[1] == 1 else arr
+        cls = np.asarray(classes) if classes is not None else _proba_to_classes(p)
+        return _from_proba_predict(p, cls)
+
+    def predict_proba(X):
+        return _two_col(raw_fn(X))
+
+    if task == "regression":
+        return ModelAdapter(predict, problem_type="regression", name=name)
+    # Default to exposing predict_proba (classification); harmless if unused.
+    return ModelAdapter(
+        predict, predict_proba, classes=classes, problem_type=task or "classification", name=name
+    )

--- a/explainx/dashboard.py
+++ b/explainx/dashboard.py
@@ -62,6 +62,7 @@ VIEWS = [
     "Full report", "Global importance", "Local explanation", "Counterfactual / recourse",
     "Feature effects (PDP / ALE)", "Interactions", "Fairness", "Bias mitigation",
     "Conformal uncertainty", "Prototypes & criticisms", "Explanation quality", "Data drift",
+    "Error analysis", "Label issues", "Target leakage", "Calibration",
 ]
 
 
@@ -278,6 +279,63 @@ def render_drift(st, ctx: Ctx) -> None:
     st.dataframe(pd.DataFrame([f.to_dict() for f in report.features]).set_index("feature"))
 
 
+def render_error_analysis(st, ctx: Ctx) -> None:
+    import pandas as pd
+
+    if ctx.y is None:
+        st.info("Select a target column to run error analysis.")
+        return
+    ea = ctx.ex.error_analysis()
+    st.metric(f"Baseline {ea.metric}", f"{ea.baseline_error:.3f}")
+    st.dataframe(pd.DataFrame([s.to_dict() for s in ea.slices]))
+    st.write("• " + ea.recommendation)
+
+
+def render_label_issues(st, ctx: Ctx) -> None:
+    import pandas as pd
+
+    if ctx.y is None:
+        st.info("Select a target column to detect label issues.")
+        return
+    li = ctx.ex.label_issues(top_k=50)
+    c1, c2 = st.columns(2)
+    c1.metric("Likely-mislabeled", li.n_issues)
+    c2.metric("Estimated noise rate", f"{li.estimated_noise_rate:.1%}")
+    st.dataframe(pd.DataFrame([i.to_dict() for i in li.issues]))
+    st.write("• " + li.recommendation)
+
+
+def render_leakage(st, ctx: Ctx) -> None:
+    import pandas as pd
+
+    if ctx.y is None:
+        st.info("Select a target column to scan for leakage.")
+        return
+    lk = ctx.ex.leakage()
+    if lk.suspected_leakage:
+        st.error("Suspected leakage: " + ", ".join(lk.suspected_leakage))
+    else:
+        st.success("No obvious target leakage.")
+    st.dataframe(pd.DataFrame([f.to_dict() for f in lk.features]).set_index("feature"))
+    st.write("• " + lk.recommendation)
+
+
+def render_calibration(st, ctx: Ctx) -> None:
+    import pandas as pd
+
+    if ctx.y is None:
+        st.info("Select a target column to assess calibration.")
+        return
+    cal = ctx.ex.calibration()
+    c1, c2 = st.columns(2)
+    c1.metric("ECE", f"{cal.ece:.3f}")
+    c2.metric("Brier", f"{cal.brier:.3f}")
+    if cal.bins:
+        df = pd.DataFrame([b.to_dict() for b in cal.bins]).set_index("mean_confidence")
+        st.line_chart(df[["accuracy"]])
+    st.write("• " + cal.recommendation)
+
+
 RENDERERS = {
     "Full report": render_full_report,
     "Global importance": render_global_importance,
@@ -291,6 +349,10 @@ RENDERERS = {
     "Prototypes & criticisms": render_prototypes,
     "Explanation quality": render_quality,
     "Data drift": render_drift,
+    "Error analysis": render_error_analysis,
+    "Label issues": render_label_issues,
+    "Target leakage": render_leakage,
+    "Calibration": render_calibration,
 }
 
 

--- a/explainx/diagnostics.py
+++ b/explainx/diagnostics.py
@@ -1,0 +1,243 @@
+"""Data-centric diagnostics that help *improve* model accuracy.
+
+Explanations tell you how a model behaves; these diagnostics tell you what to
+*fix* to make it more accurate -- the data-centric-AI playbook:
+
+* **error_analysis** -- discover the data slices where the model fails worst, so
+  you know where to add data, add features, or split the model.
+* **find_label_issues** -- flag likely-mislabeled rows (confident learning);
+  cleaning them is one of the highest-ROI accuracy levers (Northcutt et al.).
+* **detect_leakage** -- find features that alone predict the target almost
+  perfectly, a red flag for target leakage that inflates offline accuracy and
+  collapses in production.
+* **assess_calibration** -- measure whether predicted probabilities are
+  trustworthy, and recommend a fix when they aren't.
+
+All return structured, JSON-serializable reports with a plain-language
+``recommendation`` an LLM agent can act on.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+import numpy as np
+import pandas as pd
+
+from .schema import (
+    ErrorAnalysis, ErrorSlice, LabelIssues, LabelIssue,
+    LeakageReport, LeakageFeature, CalibrationReport, CalibrationBin,
+)
+from .utils import predict, predict_scores
+
+
+# --------------------------------------------------------------------------- #
+# Error analysis / slice discovery
+# --------------------------------------------------------------------------- #
+def error_analysis(
+    model: Any, X: pd.DataFrame, y: Any, problem_type: str,
+    n_bins: int = 4, min_size: int = 10, min_lift: float = 1.5, top_k: int = 8,
+) -> ErrorAnalysis:
+    y = np.asarray(y)
+    y_pred = predict(model, X)
+    if problem_type == "classification":
+        err = (y_pred != y).astype(float)
+        metric = "misclassification_rate"
+    else:
+        err = np.abs(y.astype(float) - y_pred.astype(float))
+        metric = "mean_absolute_error"
+    baseline = float(err.mean())
+
+    slices: list[ErrorSlice] = []
+    for col in X.columns:
+        series = X[col]
+        if pd.api.types.is_numeric_dtype(series) and series.nunique() > n_bins:
+            edges = np.unique(np.quantile(series, np.linspace(0, 1, n_bins + 1)))
+            for i in range(len(edges) - 1):
+                lo, hi = edges[i], edges[i + 1]
+                mask = (series >= lo) & (series <= hi) if i == len(edges) - 2 else (series >= lo) & (series < hi)
+                cond = f"{lo:.3g} <= {col} <= {hi:.3g}" if i == len(edges) - 2 else f"{lo:.3g} <= {col} < {hi:.3g}"
+                _add_slice(slices, mask.to_numpy(), err, col, cond, baseline, min_size, min_lift)
+        else:
+            for val in series.unique():
+                mask = (series == val).to_numpy()
+                _add_slice(slices, mask, err, col, f"{col} == {val}", baseline, min_size, min_lift)
+
+    slices.sort(key=lambda s: s.lift * s.size, reverse=True)
+    slices = slices[:top_k]
+    rec = (
+        f"Worst slice: '{slices[0].condition}' has {slices[0].lift:.1f}x the average error. "
+        "Prioritise more/better data or features there, or train a specialised model for that segment."
+        if slices else "No slice exceeded the error-lift threshold; error is spread fairly evenly."
+    )
+    return ErrorAnalysis(problem_type=problem_type, metric=metric, baseline_error=baseline,
+                         slices=slices, recommendation=rec)
+
+
+def _add_slice(slices, mask, err, col, cond, baseline, min_size, min_lift):
+    n = int(mask.sum())
+    if n < min_size:
+        return
+    slice_err = float(err[mask].mean())
+    lift = slice_err / baseline if baseline > 0 else 0.0
+    if lift >= min_lift:
+        slices.append(ErrorSlice(feature=col, condition=cond, size=n,
+                                 error=slice_err, baseline_error=baseline, lift=float(lift)))
+
+
+# --------------------------------------------------------------------------- #
+# Label-error detection (confident learning)
+# --------------------------------------------------------------------------- #
+def find_label_issues(
+    model: Any, X: pd.DataFrame, y: Any, cv: int = 3, top_k: Optional[int] = 50,
+) -> LabelIssues:
+    y = np.asarray(y)
+    classes = np.unique(y)
+    class_index = {c: i for i, c in enumerate(classes)}
+
+    proba, out_of_sample = _oos_proba(model, X, y, cv)
+    if proba is None:
+        raise ValueError("Label-issue detection needs a classifier with predict_proba.")
+
+    # Per-class self-confidence thresholds (confident learning).
+    self_conf = np.array([proba[i, class_index[y[i]]] for i in range(len(y))])
+    thresholds = {c: float(self_conf[y == c].mean()) if np.any(y == c) else 0.0 for c in classes}
+
+    issues: list[LabelIssue] = []
+    for i in range(len(y)):
+        argmax = int(np.argmax(proba[i]))
+        suggested = classes[argmax]
+        if suggested != y[i] and self_conf[i] < thresholds[y[i]]:
+            issues.append(LabelIssue(index=int(i), given_label=_native(y[i]),
+                                     suggested_label=_native(suggested), confidence=float(proba[i, argmax])))
+    issues.sort(key=lambda it: it.confidence, reverse=True)
+    n_issues = len(issues)
+    if top_k:
+        issues = issues[:top_k]
+    rec = (
+        f"~{n_issues} of {len(y)} labels look wrong ({n_issues/len(y):.1%}). Review the highest-confidence "
+        "ones; relabelling or removing them typically improves accuracy more than model tuning."
+        if n_issues else "No systematic label issues detected."
+    )
+    return LabelIssues(n_checked=int(len(y)), n_issues=n_issues,
+                       estimated_noise_rate=float(n_issues / len(y)), out_of_sample=out_of_sample,
+                       issues=issues, recommendation=rec)
+
+
+def _oos_proba(model, X, y, cv):
+    """Out-of-sample probabilities via cross-val when possible (less optimistic)."""
+    try:
+        from sklearn.base import clone, is_classifier
+        from sklearn.model_selection import cross_val_predict
+
+        if is_classifier(model):
+            proba = cross_val_predict(clone(model), X, y, cv=cv, method="predict_proba")
+            return np.asarray(proba), True
+    except Exception:
+        pass
+    # Fallback: in-sample probabilities from the fitted model (optimistic).
+    p = predict_scores_proba(model, X)
+    return (None, False) if p is None else (p, False)
+
+
+def predict_scores_proba(model, X):
+    if hasattr(model, "predict_proba"):
+        try:
+            return np.asarray(model.predict_proba(X))
+        except Exception:
+            try:
+                return np.asarray(model.predict_proba(X.to_numpy()))
+            except Exception:
+                return None
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Target-leakage detection
+# --------------------------------------------------------------------------- #
+def detect_leakage(
+    model: Any, X: pd.DataFrame, y: Any, problem_type: str, threshold: Optional[float] = None,
+) -> LeakageReport:
+    from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+    from sklearn.model_selection import cross_val_score
+
+    y = np.asarray(y)
+    is_clf = problem_type == "classification"
+    metric = "roc_auc" if (is_clf and len(np.unique(y)) == 2) else ("accuracy" if is_clf else "r2")
+    thr = threshold if threshold is not None else (0.95 if metric != "roc_auc" else 0.98)
+
+    feats: list[LeakageFeature] = []
+    for col in X.columns:
+        xcol = pd.get_dummies(X[[col]], drop_first=False)
+        try:
+            est = DecisionTreeClassifier(max_depth=3, random_state=0) if is_clf else DecisionTreeRegressor(max_depth=3, random_state=0)
+            score = float(np.mean(cross_val_score(est, xcol, y, cv=3, scoring=metric)))
+        except Exception:
+            score = 0.0
+        feats.append(LeakageFeature(feature=col, solo_score=score, suspected=score >= thr))
+
+    feats.sort(key=lambda f: f.solo_score, reverse=True)
+    suspected = [f.feature for f in feats if f.suspected]
+    rec = (
+        f"Possible target leakage: {', '.join(suspected)} alone predict the target with "
+        f"{metric} >= {thr}. Confirm these are available at prediction time and not a proxy for the label."
+        if suspected else "No single feature predicts the target suspiciously well; no obvious leakage."
+    )
+    return LeakageReport(metric=metric, threshold=float(thr), features=feats,
+                         suspected_leakage=suspected, recommendation=rec)
+
+
+# --------------------------------------------------------------------------- #
+# Calibration
+# --------------------------------------------------------------------------- #
+def assess_calibration(model: Any, X: pd.DataFrame, y: Any, n_bins: int = 10) -> CalibrationReport:
+    proba = predict_scores_proba(model, X)
+    if proba is None:
+        raise ValueError("Calibration needs a classifier with predict_proba.")
+    y = np.asarray(y)
+    classes = getattr(model, "classes_", np.unique(y))
+
+    conf = proba.max(axis=1)
+    pred = np.asarray(classes)[np.argmax(proba, axis=1)]
+    correct = (pred == y).astype(float)
+
+    edges = np.linspace(0, 1, n_bins + 1)
+    bins, ece = [], 0.0
+    for i in range(n_bins):
+        m = (conf > edges[i]) & (conf <= edges[i + 1]) if i > 0 else (conf >= edges[i]) & (conf <= edges[i + 1])
+        if not m.any():
+            continue
+        acc = float(correct[m].mean()); mc = float(conf[m].mean()); cnt = int(m.sum())
+        bins.append(CalibrationBin(mean_confidence=mc, accuracy=acc, count=cnt))
+        ece += (cnt / len(y)) * abs(acc - mc)
+
+    # Brier score (binary uses positive-class prob; multiclass: one-vs-rest mean).
+    if proba.shape[1] == 2:
+        pos = classes[-1]
+        brier = float(np.mean((proba[:, -1] - (y == pos).astype(float)) ** 2))
+    else:
+        onehot = np.zeros_like(proba)
+        idx = {c: i for i, c in enumerate(classes)}
+        for i, yi in enumerate(y):
+            if yi in idx:
+                onehot[i, idx[yi]] = 1.0
+        brier = float(np.mean(np.sum((proba - onehot) ** 2, axis=1)))
+
+    well = ece < 0.1
+    rec = (
+        "Probabilities are reasonably calibrated."
+        if well else
+        f"ECE={ece:.3f} indicates miscalibration; wrap the model in sklearn's "
+        "CalibratedClassifierCV (isotonic or sigmoid/Platt) before trusting probabilities."
+    )
+    return CalibrationReport(ece=float(ece), brier=brier, well_calibrated=well,
+                             bins=bins, recommendation=rec)
+
+
+def _native(value: Any) -> Any:
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        return float(value)
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    return value

--- a/explainx/explainer.py
+++ b/explainx/explainer.py
@@ -30,6 +30,8 @@ from .mitigation import mitigate_demographic_parity
 from .interactions import feature_interactions
 from .prototypes import prototypes_and_criticisms
 from .schema import PrototypesResult
+from .adapters import wrap_model
+from .diagnostics import error_analysis, find_label_issues, detect_leakage, assess_calibration
 from .summary import build_summary
 
 
@@ -45,10 +47,16 @@ class ModelExplainer:
         problem_type: Optional[str] = None,
         use_shap: bool = True,
     ):
-        self.model = model
+        # Adapt non-sklearn frameworks (native boosters, Keras, PyTorch, ...) to
+        # the predict/predict_proba convention; sklearn-compatible models pass through.
+        self.model = wrap_model(model)
         self.X = as_dataframe(X, feature_names)
         self.y = None if y is None else np.asarray(y)
-        self.problem_type = problem_type or detect_problem_type(model, self.y)
+        self.problem_type = (
+            problem_type
+            or getattr(self.model, "problem_type", None)
+            or detect_problem_type(self.model, self.y)
+        )
         self.use_shap = use_shap
 
     # --- individual analyses ------------------------------------------------
@@ -148,6 +156,27 @@ class ModelExplainer:
         return PrototypesResult(
             method="mmd_rbf", prototype_indices=protos, criticism_indices=crits
         )
+
+    # --- data-centric diagnostics (improve accuracy) ------------------------
+    def _require_y(self, what):
+        if self.y is None:
+            raise ValueError(f"{what} requires ground-truth y.")
+
+    def error_analysis(self, top_k: int = 8, min_lift: float = 1.5):
+        self._require_y("error_analysis")
+        return error_analysis(self.model, self.X, self.y, self.problem_type, top_k=top_k, min_lift=min_lift)
+
+    def label_issues(self, cv: int = 3, top_k: int = 50):
+        self._require_y("label_issues")
+        return find_label_issues(self.model, self.X, self.y, cv=cv, top_k=top_k)
+
+    def leakage(self, threshold: Optional[float] = None):
+        self._require_y("leakage")
+        return detect_leakage(self.model, self.X, self.y, self.problem_type, threshold=threshold)
+
+    def calibration(self, n_bins: int = 10):
+        self._require_y("calibration")
+        return assess_calibration(self.model, self.X, self.y, n_bins=n_bins)
 
     # --- full report --------------------------------------------------------
     def report(

--- a/explainx/mcp_server.py
+++ b/explainx/mcp_server.py
@@ -290,6 +290,34 @@ def _make_server():
         return {"prototype_indices": protos, "criticism_indices": crits}
 
     @mcp.tool()
+    def error_analysis(model_path: str, data_path: str, target_column: str, top_k: int = 8) -> dict:
+        """Find the data slices where the model fails worst (slice discovery)."""
+        model = load_model(model_path)
+        X, y = load_xy(data_path, target_column)
+        return ModelExplainer(model, X, y).error_analysis(top_k=top_k).to_dict()
+
+    @mcp.tool()
+    def label_issues(model_path: str, data_path: str, target_column: str, top_k: int = 50) -> dict:
+        """Flag likely-mislabeled rows (confident learning) to review/relabel."""
+        model = load_model(model_path)
+        X, y = load_xy(data_path, target_column)
+        return ModelExplainer(model, X, y).label_issues(top_k=top_k).to_dict()
+
+    @mcp.tool()
+    def detect_target_leakage(model_path: str, data_path: str, target_column: str) -> dict:
+        """Detect features that alone predict the target suspiciously well (leakage)."""
+        model = load_model(model_path)
+        X, y = load_xy(data_path, target_column)
+        return ModelExplainer(model, X, y).leakage().to_dict()
+
+    @mcp.tool()
+    def assess_calibration(model_path: str, data_path: str, target_column: str) -> dict:
+        """Measure probability calibration (ECE, Brier) and recommend a fix."""
+        model = load_model(model_path)
+        X, y = load_xy(data_path, target_column)
+        return ModelExplainer(model, X, y).calibration().to_dict()
+
+    @mcp.tool()
     def html_report(
         model_path: str,
         data_path: str,

--- a/explainx/schema.py
+++ b/explainx/schema.py
@@ -291,6 +291,83 @@ class PrototypesResult(_Serializable):
 
 
 @dataclass
+class ErrorSlice(_Serializable):
+    feature: str
+    condition: str
+    size: int
+    error: float
+    baseline_error: float
+    lift: float  # slice error / baseline error (>1 means worse than average)
+
+
+@dataclass
+class ErrorAnalysis(_Serializable):
+    """Where the model fails: data slices with elevated error (slice discovery)."""
+
+    problem_type: str
+    metric: str
+    baseline_error: float
+    slices: list[ErrorSlice] = field(default_factory=list)
+    recommendation: str = ""
+
+
+@dataclass
+class LabelIssue(_Serializable):
+    index: int
+    given_label: Any
+    suggested_label: Any
+    confidence: float
+
+
+@dataclass
+class LabelIssues(_Serializable):
+    """Likely-mislabeled rows (confident-learning style) to review/relabel."""
+
+    n_checked: int
+    n_issues: int
+    estimated_noise_rate: float
+    out_of_sample: bool
+    issues: list[LabelIssue] = field(default_factory=list)
+    recommendation: str = ""
+
+
+@dataclass
+class LeakageFeature(_Serializable):
+    feature: str
+    solo_score: float
+    suspected: bool
+
+
+@dataclass
+class LeakageReport(_Serializable):
+    """Features that alone predict the target suspiciously well (target leakage)."""
+
+    metric: str
+    threshold: float
+    features: list[LeakageFeature] = field(default_factory=list)
+    suspected_leakage: list[str] = field(default_factory=list)
+    recommendation: str = ""
+
+
+@dataclass
+class CalibrationBin(_Serializable):
+    mean_confidence: float
+    accuracy: float
+    count: int
+
+
+@dataclass
+class CalibrationReport(_Serializable):
+    """How well predicted probabilities match observed frequencies."""
+
+    ece: float
+    brier: float
+    well_calibrated: bool
+    bins: list[CalibrationBin] = field(default_factory=list)
+    recommendation: str = ""
+
+
+@dataclass
 class ExplanationReport(_Serializable):
     """The full explainability report for a model + dataset."""
 

--- a/explainx/tests/test_adapters.py
+++ b/explainx/tests/test_adapters.py
@@ -1,0 +1,87 @@
+"""Tests for universal framework support via the model adapter."""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from explainx import ModelExplainer, explain_model, wrap_model
+
+
+@pytest.fixture
+def data():
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(
+        n_samples=200, n_features=5, n_informative=4, n_redundant=0, random_state=0
+    )
+    return pd.DataFrame(X, columns=[f"f{i}" for i in range(5)]), y
+
+
+def test_sklearn_passthrough(data):
+    from sklearn.ensemble import RandomForestClassifier
+
+    X, y = data
+    model = RandomForestClassifier(n_estimators=20, random_state=0).fit(X, y)
+    assert wrap_model(model) is model  # unchanged
+
+
+def test_xgboost_sklearn_wrapper_works_directly(data):
+    xgb = pytest.importorskip("xgboost")
+    X, y = data
+    model = xgb.XGBClassifier(n_estimators=30, max_depth=3, verbosity=0).fit(X, y)
+    report = explain_model(model, X, y, n_local=1)
+    assert report.problem_type == "classification"
+    assert report.metrics.metrics["accuracy"] > 0.5
+    json.dumps(report.to_dict())
+
+
+def test_native_xgboost_booster_via_adapter(data):
+    xgb = pytest.importorskip("xgboost")
+    X, y = data
+    booster = xgb.train(
+        {"objective": "binary:logistic", "max_depth": 3}, xgb.DMatrix(X, label=y), num_boost_round=30
+    )
+    ex = ModelExplainer(wrap_model(booster, task="classification"), X, y)
+    assert ex.problem_type == "classification"
+    assert ex.metrics().metrics["accuracy"] > 0.5
+    assert ex.importance().features
+    assert ex.explain(0, top_k=3).contributions
+
+
+def test_native_lightgbm_booster_via_adapter(data):
+    lgb = pytest.importorskip("lightgbm")
+    X, y = data
+    booster = lgb.train(
+        {"objective": "binary", "verbose": -1}, lgb.Dataset(X, label=y), num_boost_round=30
+    )
+    ex = ModelExplainer(wrap_model(booster, task="classification"), X, y)
+    assert ex.problem_type == "classification"
+    assert ex.metrics().metrics["accuracy"] > 0.5
+    assert ex.fairness("f0") is not None or True  # smoke
+
+
+def test_custom_predict_proba_fn(data):
+    """A fully custom model exposed only through a predict_proba function."""
+    from sklearn.ensemble import RandomForestClassifier
+
+    X, y = data
+    rf = RandomForestClassifier(n_estimators=20, random_state=0).fit(X, y)
+    wrapped = wrap_model(predict_proba_fn=lambda Z: rf.predict_proba(Z), classes=[0, 1])
+    report = explain_model(wrapped, X, y, n_local=1)
+    assert report.problem_type == "classification"
+    assert report.global_importance.features
+
+
+def test_custom_regression_predict_fn():
+    from sklearn.linear_model import LinearRegression
+    from sklearn.datasets import make_regression
+
+    X, y = make_regression(n_samples=150, n_features=4, noise=0.1, random_state=0)
+    Xdf = pd.DataFrame(X, columns=[f"f{i}" for i in range(4)])
+    lr = LinearRegression().fit(Xdf, y)
+    wrapped = wrap_model(predict_fn=lambda Z: lr.predict(Z), task="regression")
+    ex = ModelExplainer(wrapped, Xdf, y)
+    assert ex.problem_type == "regression"
+    assert "r2" in ex.metrics().metrics

--- a/explainx/tests/test_diagnostics.py
+++ b/explainx/tests/test_diagnostics.py
@@ -1,0 +1,90 @@
+"""Tests for the data-centric accuracy diagnostics."""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from explainx import ModelExplainer
+
+
+@pytest.fixture
+def clf_data():
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(n_samples=400, n_features=6, n_informative=4, n_redundant=0, random_state=0)
+    return pd.DataFrame(X, columns=[f"f{i}" for i in range(6)]), y
+
+
+def test_error_analysis(clf_data):
+    X, y = clf_data
+    model = RandomForestClassifier(n_estimators=40, random_state=0).fit(X, y)
+    ea = ModelExplainer(model, X, y).error_analysis()
+    assert ea.metric == "misclassification_rate"
+    assert 0.0 <= ea.baseline_error <= 1.0
+    for s in ea.slices:
+        assert s.lift >= 1.5 and s.size >= 10
+    assert ea.recommendation
+    json.dumps(ea.to_dict())
+
+
+def test_label_issues_detects_injected_noise(clf_data):
+    X, y = clf_data
+    y_noisy = y.copy()
+    rng = np.random.RandomState(1)
+    flip = rng.choice(len(y), size=40, replace=False)
+    y_noisy[flip] = 1 - y_noisy[flip]  # inject 10% label noise
+
+    model = LogisticRegression(max_iter=500)
+    li = ModelExplainer(model.fit(X, y_noisy), X, y_noisy).label_issues()
+    assert li.out_of_sample is True  # cross-val path used for sklearn clf
+    assert li.n_issues > 0
+    # Flagged rows should overlap the truly-flipped ones well above chance.
+    flagged = {it.index for it in li.issues}
+    overlap = len(flagged & set(flip.tolist()))
+    chance = len(flagged) * len(flip) / len(y)  # expected overlap if random
+    assert overlap > 1.5 * chance and overlap >= 5
+    json.dumps(li.to_dict())
+
+
+def test_leakage_detection():
+    rng = np.random.RandomState(0)
+    n = 400
+    noise = rng.normal(size=(n, 3))
+    y = (noise[:, 0] + rng.normal(0, 0.5, n) > 0).astype(int)
+    X = pd.DataFrame(noise, columns=["a", "b", "c"])
+    X["leak"] = y  # a copy of the label = textbook leakage
+    model = RandomForestClassifier(n_estimators=30, random_state=0).fit(X, y)
+
+    rep = ModelExplainer(model, X, y).leakage()
+    assert "leak" in rep.suspected_leakage
+    assert rep.recommendation
+
+
+def test_calibration_report(clf_data):
+    X, y = clf_data
+    model = RandomForestClassifier(n_estimators=40, random_state=0).fit(X, y)
+    cal = ModelExplainer(model, X, y).calibration()
+    assert 0.0 <= cal.ece <= 1.0
+    assert cal.bins
+    assert isinstance(cal.well_calibrated, bool)
+    assert cal.recommendation
+    json.dumps(cal.to_dict())
+
+
+def test_diagnostics_work_through_adapter():
+    """Diagnostics should work on a non-sklearn model via the adapter."""
+    xgb = pytest.importorskip("xgboost")
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification(n_samples=300, n_features=5, n_informative=4, n_redundant=0, random_state=0)
+    Xdf = pd.DataFrame(X, columns=[f"f{i}" for i in range(5)])
+    booster = xgb.train({"objective": "binary:logistic"}, xgb.DMatrix(Xdf, label=y), num_boost_round=25)
+    ex = ModelExplainer(__import__("explainx").wrap_model(booster, task="classification"), Xdf, y)
+    ea = ex.error_analysis()
+    cal = ex.calibration()
+    assert ea.baseline_error >= 0
+    assert cal.bins


### PR DESCRIPTION
Three additions, all tested (54 passing):

**1. Works with every famous ML framework.** explainX already consumes any scikit-learn-API model (sklearn, XGBoost, LightGBM, CatBoost) directly. New `wrap_model()` adapts the rest — native XGBoost/LightGBM `Booster`s, Keras/TensorFlow, PyTorch `nn.Module`, statsmodels, and any custom `predict_fn`/`predict_proba_fn`. `ModelExplainer` auto-wraps non-sklearn models.

**2. Data-centric diagnostics that improve accuracy** (researched: data-centric AI / confident learning / slice discovery):
- `error_analysis` — worst-performing data slices (where to add data/features)
- `label_issues` — likely-mislabeled rows via confident learning (cross-validated)
- `leakage` — features that alone predict the target (target-leakage red flag)
- `calibration` — ECE/Brier + fix recommendation

Each is a `ModelExplainer` method, an MCP tool (now **23 tools**), and a dashboard view.

**3. Per-framework examples** in [`examples/`](examples/) — one runnable, commented file each for sklearn, XGBoost (sklearn + native Booster), LightGBM, CatBoost, Keras/TF, PyTorch, statsmodels, and a custom function — for humans and LLM agents to study. Verified end-to-end for the installed frameworks (sklearn, XGBoost, LightGBM, statsmodels, custom).

No breaking changes; `explainx-3.0.0` artifacts rebuilt and pass `twine check`.

https://claude.ai/code/session_01PFQfw58kiWwLAqoyWAjp9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFQfw58kiWwLAqoyWAjp9K)_